### PR TITLE
splitter contract updates

### DIFF
--- a/contracts/Splitter.sol
+++ b/contracts/Splitter.sol
@@ -9,6 +9,7 @@ import "./inherited/ERC20.sol";
 contract Splitter {
 
     /**
+     * @param fromAddress - the address to send the tokens from
      * @param toFirst - the address of the first account
      * @param valueFirst - ERC20 tokens to be sent to toFirst
      * @param toSecond - the address of the second account
@@ -16,6 +17,7 @@ contract Splitter {
      * @param tokenAddress - address of the ERC20 token
     */
     function splitTransfer(
+        address fromAddress,
         address toFirst,
         address toSecond,
         uint256 valueFirst,
@@ -24,8 +26,8 @@ contract Splitter {
     )
         external
     {
-        ERC20(tokenAddress).transferFrom(msg.sender, toFirst, valueFirst);
-        ERC20(tokenAddress).transferFrom(msg.sender, toSecond, valueSecond);
+        ERC20(tokenAddress).transferFrom(fromAddress, toFirst, valueFirst);
+        ERC20(tokenAddress).transferFrom(fromAddress, toSecond, valueSecond);
     }
 
 }

--- a/test/test_splitter.js
+++ b/test/test_splitter.js
@@ -29,7 +29,7 @@ contract("Splitter", () => {
     assert.strictEqual(parseInt(accountZeroBalance), parseInt(totalSupply));
 
     let approval = await testToken.methods.approve(splitter._address, web3.utils.toHex(100)).send(accounts[0]);
-    let splitTransfer = await splitter.methods.splitTransfer(accounts[1], accounts[2], 10, 90, testToken._address).send(accounts[0]);
+    let splitTransfer = await splitter.methods.splitTransfer(accounts[0], accounts[1], accounts[2], 10, 90, testToken._address).send(accounts[0]);
 
     accountZeroBalance = await testToken.methods.balanceOf(accounts[0]).call();
     accountOneBalance = await testToken.methods.balanceOf(accounts[1]).call();


### PR DESCRIPTION
these changes allow you to send splitter contracts from any arbitrary address.

this allows us to only use required one transaction (an approve() to the from address) from the end user when contributing to a gitcoin grant.  the second transaction to the splitter address should be emitted from gitcoin.